### PR TITLE
✨ Feat : AI 키워드 분석 페이지 백엔드 구현

### DIFF
--- a/src/main/java/com/jangsacartel/biz/ai/controller/AiAnalysisController.java
+++ b/src/main/java/com/jangsacartel/biz/ai/controller/AiAnalysisController.java
@@ -1,0 +1,46 @@
+package com.jangsacartel.biz.ai.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jangsacartel.biz.ai.dto.BizAiWeeklyResponseDTO;
+import com.jangsacartel.biz.ai.enums.WeekPreset;
+import com.jangsacartel.biz.ai.service.AiAnalysisService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Api(tags = "AI 분석 컨트롤러")
+public class AiAnalysisController {
+
+    private final AiAnalysisService aiAnalysisService;
+
+    @ApiOperation(value = "주차별 HOT 키워드/워드클라우드 분석")
+    @GetMapping("/ai/analysis/weekly")
+    public ResponseEntity<BizAiWeeklyResponseDTO> weekly(
+        @ApiParam(value = "주차 프리셋(THIS/LAST). 미지정 시 LAST", required = false, example = "LAST")
+        @RequestParam(value = "week", required = false, defaultValue = "LAST")
+        WeekPreset week,
+
+        @ApiParam(value = "Top K 키워드 개수", required = false, example = "10")
+        @RequestParam(value = "topK", required = false, defaultValue = "10")
+        int topK,
+
+        @ApiParam(value = "DB에서 가져올 게시글 최대 개수", required = false, example = "500")
+        @RequestParam(value = "limit", required = false, defaultValue = "500")
+        int limit
+    ) {
+        BizAiWeeklyResponseDTO res = aiAnalysisService.getWeeklyAnalysis(week, topK, limit);
+        return ResponseEntity.ok(res);
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiKeywordDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiKeywordDTO.java
@@ -1,0 +1,25 @@
+package com.jangsacartel.biz.ai.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "핫 키워드 항목(score/freq)")
+public class BizAiKeywordDTO {
+
+    @ApiModelProperty(value = "키워드", example = "불")
+    private String keyword;
+
+    @ApiModelProperty(value = "TF-IDF 기반 점수(정수로 반올림)", example = "24")
+    private int score;
+
+    @ApiModelProperty(value = "빈도(주차 전체에서 등장 횟수)", example = "18")
+    private int freq;
+}

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiKeywordDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiKeywordDTO.java
@@ -11,15 +11,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "핫 키워드 항목(score/freq)")
+@ApiModel(description = "키워드/점수(TF-IDF)")
 public class BizAiKeywordDTO {
 
     @ApiModelProperty(value = "키워드", example = "불")
     private String keyword;
 
-    @ApiModelProperty(value = "TF-IDF 기반 점수(정수로 반올림)", example = "24")
+    @ApiModelProperty(value = "TF-IDF 기반 점수)", example = "24")
     private int score;
-
-    @ApiModelProperty(value = "빈도(주차 전체에서 등장 횟수)", example = "18")
-    private int freq;
 }

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiPostDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiPostDTO.java
@@ -1,0 +1,25 @@
+package com.jangsacartel.biz.ai.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "Biz-AI에 전달하는 게시글 단위 DTO")
+public class BizAiPostDTO {
+
+	@ApiModelProperty(value = "게시글 ID(문자열)", example = "123")
+    private String postId;
+
+    @ApiModelProperty(value = "게시글 제목", example = "불(fire) 대응 매뉴얼 점검")
+    private String title;
+
+    @ApiModelProperty(value = "게시글 본문", example = "불 대응 프로세스 점검. FIRE drill 실시.")
+    private String content;
+}

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyRequestDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyRequestDTO.java
@@ -1,0 +1,27 @@
+package com.jangsacartel.biz.ai.dto;
+
+import java.util.List;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "주차별 분석 요청(BE -> Biz-AI)")
+public class BizAiWeeklyRequestDTO {
+
+    @ApiModelProperty(value = "주차 라벨", example = "2025년 12월 2주차")
+    private String weekLabel;
+
+    @ApiModelProperty(value = "상위 키워드 개수", example = "10")
+    private int topK;
+
+    @ApiModelProperty(value = "주차별 게시글 목록(최소 title/content)", required = true)
+    private List<BizAiPostDTO> posts;
+}

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyResponseDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyResponseDTO.java
@@ -13,15 +13,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "주차별 분석 응답(Biz-AI -> BE -> FE)")
+@ApiModel(description = "Biz-AI 주간 분석 응답 DTO")
 public class BizAiWeeklyResponseDTO {
 
     @ApiModelProperty(value = "주차 라벨", example = "2025년 12월 2주차")
     private String weekLabel;
 
-    @ApiModelProperty(value = "상위 키워드 목록(score/freq 포함)")
+    @ApiModelProperty(value = "상위 키워드 목록(score는 TF-IDF 점수)", required = true)
     private List<BizAiKeywordDTO> topKeywords;
 
-    @ApiModelProperty(value = "워드클라우드 base64 PNG(data URI)", example = "data:image/png;base64,iVBORw0K...")
+    @ApiModelProperty(value = "워드클라우드(data URI)", example = "data:image/png;base64,iVBORw0K...")
     private String wordcloudPngBase64;
 }

--- a/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyResponseDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/BizAiWeeklyResponseDTO.java
@@ -1,0 +1,27 @@
+package com.jangsacartel.biz.ai.dto;
+
+import java.util.List;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "주차별 분석 응답(Biz-AI -> BE -> FE)")
+public class BizAiWeeklyResponseDTO {
+
+    @ApiModelProperty(value = "주차 라벨", example = "2025년 12월 2주차")
+    private String weekLabel;
+
+    @ApiModelProperty(value = "상위 키워드 목록(score/freq 포함)")
+    private List<BizAiKeywordDTO> topKeywords;
+
+    @ApiModelProperty(value = "워드클라우드 base64 PNG(data URI)", example = "data:image/png;base64,iVBORw0K...")
+    private String wordcloudPngBase64;
+}

--- a/src/main/java/com/jangsacartel/biz/ai/dto/PostLiteDTO.java
+++ b/src/main/java/com/jangsacartel/biz/ai/dto/PostLiteDTO.java
@@ -1,0 +1,25 @@
+package com.jangsacartel.biz.ai.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "DB에서 조회한 게시글 최소 정보 DTO")
+public class PostLiteDTO {
+	
+	 	@ApiModelProperty(value = "게시글 ID", example = "123")
+	    private Long postId;
+
+	    @ApiModelProperty(value = "게시글 제목", example = "Gemini 2.5 Flash 연결 이슈")
+	    private String title;
+
+	    @ApiModelProperty(value = "게시글 본문", example = "응답 지연 발생. 캐싱 전략 점검 필요.")
+	    private String content;
+}

--- a/src/main/java/com/jangsacartel/biz/ai/enums/WeekPreset.java
+++ b/src/main/java/com/jangsacartel/biz/ai/enums/WeekPreset.java
@@ -1,0 +1,6 @@
+package com.jangsacartel.biz.ai.enums;
+
+public enum WeekPreset {
+	THIS,
+    LAST
+}

--- a/src/main/java/com/jangsacartel/biz/ai/mapper/AiMapper.java
+++ b/src/main/java/com/jangsacartel/biz/ai/mapper/AiMapper.java
@@ -1,0 +1,19 @@
+package com.jangsacartel.biz.ai.mapper;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.jangsacartel.biz.ai.dto.PostLiteDTO;
+
+@Mapper
+public interface AiMapper {
+
+    List<PostLiteDTO> selectPostsByDateRange(
+        @Param("start") Timestamp start,
+        @Param("end") Timestamp end,
+        @Param("limit") int limit
+    );
+}

--- a/src/main/java/com/jangsacartel/biz/ai/mapper/AiMapper.java
+++ b/src/main/java/com/jangsacartel/biz/ai/mapper/AiMapper.java
@@ -3,14 +3,12 @@ package com.jangsacartel.biz.ai.mapper;
 import java.sql.Timestamp;
 import java.util.List;
 
-import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.jangsacartel.biz.ai.dto.PostLiteDTO;
 
-@Mapper
 public interface AiMapper {
-
+	
     List<PostLiteDTO> selectPostsByDateRange(
         @Param("start") Timestamp start,
         @Param("end") Timestamp end,

--- a/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisService.java
+++ b/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisService.java
@@ -1,0 +1,9 @@
+package com.jangsacartel.biz.ai.service;
+
+import com.jangsacartel.biz.ai.dto.BizAiWeeklyResponseDTO;
+import com.jangsacartel.biz.ai.enums.WeekPreset;
+
+public interface AiAnalysisService {
+    BizAiWeeklyResponseDTO getWeeklyAnalysis(WeekPreset weekPreset, int limit, int topK);
+}
+

--- a/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisServiceImpl.java
@@ -81,11 +81,11 @@ public class AiAnalysisServiceImpl implements AiAnalysisService {
         String weekLabel = WeekLabelUtil.buildLabel(start);
 
         // 데이터가 없으면 AI 서버 호출하지 않고 기본 응답
-        if (posts == null || posts.isEmpty()) {
+        if (posts == null || posts.size() < 10) {
             BizAiWeeklyResponseDTO empty = new BizAiWeeklyResponseDTO();
             empty.setWeekLabel(weekLabel);
             empty.setTopKeywords(Collections.emptyList());
-            empty.setWordcloudPngBase64(null); 
+            empty.setWordcloudPngBase64(null);
             return empty;
         }
 

--- a/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/ai/service/AiAnalysisServiceImpl.java
@@ -1,0 +1,120 @@
+package com.jangsacartel.biz.ai.service;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.jangsacartel.biz.ai.dto.BizAiPostDTO;
+import com.jangsacartel.biz.ai.dto.BizAiWeeklyRequestDTO;
+import com.jangsacartel.biz.ai.dto.BizAiWeeklyResponseDTO;
+import com.jangsacartel.biz.ai.dto.PostLiteDTO;
+import com.jangsacartel.biz.ai.enums.WeekPreset;
+import com.jangsacartel.biz.ai.mapper.AiMapper;
+import com.jangsacartel.biz.ai.util.WeekLabelUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AiAnalysisServiceImpl implements AiAnalysisService {
+
+    private final AiMapper aiMapper;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${biz.ai.base-url}")
+    private String baseUrl;
+
+    @Value("${biz.ai.api-key}")
+    private String apiKey;
+
+    @Override
+    public BizAiWeeklyResponseDTO getWeeklyAnalysis(WeekPreset weekPreset, int limit, int topK) {
+
+        // 1) WeekPreset → start/end 계산 (주 시작: 월요일, end는 exclusive)
+        LocalDate today = LocalDate.now();
+
+        LocalDate thisWeekStart = today.with(java.time.DayOfWeek.MONDAY);
+        LocalDate thisWeekEnd = thisWeekStart.plusDays(7);
+
+        LocalDate start;
+        LocalDate end;
+
+        switch (weekPreset) {
+            case THIS:
+                start = thisWeekStart;
+                end = thisWeekEnd;
+                break;
+            case LAST:
+            default:
+                start = thisWeekStart.minusDays(7);
+                end = thisWeekStart;
+                break;
+        }
+
+        // 2) 기존 로직(LocalDate start/end 버전)으로 위임
+        return getWeeklyAnalysis(start, end, topK, limit);
+    }
+
+    public BizAiWeeklyResponseDTO getWeeklyAnalysis(LocalDate start, LocalDate end, int topK, int limit) {
+
+        // 기간 범위: start inclusive, end exclusive
+        LocalDateTime startDt = start.atStartOfDay();
+        LocalDateTime endDt = end.atStartOfDay();
+
+        List<PostLiteDTO> posts = aiMapper.selectPostsByDateRange(
+            Timestamp.valueOf(startDt),
+            Timestamp.valueOf(endDt),
+            limit
+        );
+
+        String weekLabel = WeekLabelUtil.buildLabel(start);
+
+        // 데이터가 없으면 AI 서버 호출하지 않고 기본 응답
+        if (posts == null || posts.isEmpty()) {
+            BizAiWeeklyResponseDTO empty = new BizAiWeeklyResponseDTO();
+            empty.setWeekLabel(weekLabel);
+            empty.setTopKeywords(Collections.emptyList());
+            empty.setWordcloudPngBase64(null); 
+            return empty;
+        }
+
+        List<BizAiPostDTO> mappedPosts = posts.stream()
+            .map(p -> BizAiPostDTO.builder()
+                .postId(p.getPostId() == null ? null : String.valueOf(p.getPostId()))
+                .title(p.getTitle())
+                .content(p.getContent())
+                .build())
+            .collect(Collectors.toList());
+
+        BizAiWeeklyRequestDTO req = BizAiWeeklyRequestDTO.builder()
+            .weekLabel(weekLabel)
+            .topK(topK)
+            .posts(mappedPosts)
+            .build();
+
+        String url = baseUrl + "/analysis/weekly";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("X-AI-KEY", apiKey);
+
+        HttpEntity<BizAiWeeklyRequestDTO> entity = new HttpEntity<>(req, headers);
+
+        try {
+            return restTemplate.postForObject(url, entity, BizAiWeeklyResponseDTO.class);
+        } catch (RestClientException e) {
+            throw new RuntimeException("Biz-AI weekly analysis call failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/ai/util/WeekLabelUtil.java
+++ b/src/main/java/com/jangsacartel/biz/ai/util/WeekLabelUtil.java
@@ -1,0 +1,37 @@
+package com.jangsacartel.biz.ai.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
+
+public class WeekLabelUtil {
+
+    private WeekLabelUtil() {}
+
+    /**
+     * 라벨 규칙
+     * - 주 범위는 월요일 시작(weekStartMonday)
+     * - 라벨의 "월"은 목요일(anchor=weekStartMonday+3)이 속한 달로 결정
+     * - "달의 1주차"는 그 달의 1일이 포함된 주
+     *
+     * 예: "2025년 12월 2주차"
+     */
+    public static String buildLabel(LocalDate weekStartMonday) {
+        LocalDate anchor = weekStartMonday.plusDays(3); // Thu
+
+        int year = anchor.getYear();
+        int month = anchor.getMonthValue();
+
+        LocalDate firstOfMonth = LocalDate.of(year, month, 1);
+
+        // 그 달 1일이 포함된 주의 월요일이 1주차 시작점
+        LocalDate firstWeekStartMonday =
+            firstOfMonth.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        long daysDiff = ChronoUnit.DAYS.between(firstWeekStartMonday, weekStartMonday);
+        int weekOfMonth = (int) (daysDiff / 7) + 1;
+
+        return String.format("%d년 %d월 %d주차", year, month, weekOfMonth);
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/ai/util/WeekRangeUtil.java
+++ b/src/main/java/com/jangsacartel/biz/ai/util/WeekRangeUtil.java
@@ -1,0 +1,40 @@
+package com.jangsacartel.biz.ai.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+
+import com.jangsacartel.biz.ai.enums.WeekPreset;
+
+public class WeekRangeUtil {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private WeekRangeUtil() {}
+
+    public static LocalDate normalizeToMonday(LocalDate date) {
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    }
+
+    /**
+     * preset 기준으로 [startMonday, endExclusiveMonday] 반환
+     * - start: 월요일
+     * - end: 다음 주 월요일(exclusive)
+     */
+    public static LocalDate[] resolveWeekRange(WeekPreset preset) {
+        LocalDate today = LocalDate.now(KST);
+
+        LocalDate thisWeekStart = normalizeToMonday(today);
+        LocalDate thisWeekEndExclusive = thisWeekStart.plusWeeks(1);
+
+        if (preset == WeekPreset.LAST) {
+            LocalDate lastWeekStart = thisWeekStart.minusWeeks(1);
+            LocalDate lastWeekEndExclusive = thisWeekStart;
+            return new LocalDate[] { lastWeekStart, lastWeekEndExclusive };
+        }
+
+        // THIS
+        return new LocalDate[] { thisWeekStart, thisWeekEndExclusive };
+    }
+}

--- a/src/main/resources/mapper/ai/AiMapper.xml
+++ b/src/main/resources/mapper/ai/AiMapper.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.jangsacartel.biz.ai.mapper.AiMapper">
+
+  <select id="selectPostsByDateRange" resultType="com.jangsacartel.biz.ai.dto.PostLiteDTO">
+    SELECT
+      post_id AS postId,
+      title,
+      content
+    FROM Post
+    WHERE created_at <![CDATA[>=]]> #{start}
+      AND created_at <![CDATA[<]]> #{end}
+      AND deleted_at IS NULL
+    ORDER BY created_at DESC
+    LIMIT #{limit}
+  </select>
+
+</mapper>

--- a/src/main/resources/mapper/ai/AiMapper.xml
+++ b/src/main/resources/mapper/ai/AiMapper.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -6,16 +6,20 @@
 <mapper namespace="com.jangsacartel.biz.ai.mapper.AiMapper">
 
   <select id="selectPostsByDateRange" resultType="com.jangsacartel.biz.ai.dto.PostLiteDTO">
-    SELECT
-      post_id AS postId,
-      title,
-      content
-    FROM Post
-    WHERE created_at <![CDATA[>=]]> #{start}
-      AND created_at <![CDATA[<]]> #{end}
-      AND deleted_at IS NULL
-    ORDER BY created_at DESC
-    LIMIT #{limit}
+	SELECT
+	    p.post_id   AS postId,
+	    MAX(p.title) AS title,
+ 		MAX(p.content) AS content
+	  FROM Post p
+	  LEFT JOIN Like_Post lp
+	    ON lp.post_id = p.post_id
+	  WHERE
+	    p.deleted_at IS NULL
+	    AND p.created_at <![CDATA[ >= ]]> #{start}
+	    AND p.created_at <![CDATA[ < ]]> #{end}
+	  GROUP BY p.post_id
+	  ORDER BY COUNT(lp.post_id) DESC, MAX(p.created_at) DESC
+	  LIMIT #{limit}
   </select>
 
 </mapper>


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #18 

### ✅ 작업한 내용

- AI 키워드 분석 페이지의 DTO, Mapper, Controller, Service 등 구현

### ❗️PR Point

- Swagger에서 API 테스트 가능합니다.
- DB에 게시글 데이터 충분히 많이 넣고 테스트 해주세요.
- 당일을 기준으로 하여 이번 주와 저번 주의 게시글 분석을 확인할 수 있습니다.

### 📸 스크린샷

<!-- 스크린 샷이 있다면 첨부해주세요 -->

closed #18 
