### PR TITLE
✨ Feat: 마이페이지: 유저 정보 및 내가 쓴 글 관리 API 구현

### DIFF
--- a/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
+++ b/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
@@ -12,7 +12,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,15 +23,18 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.jangsacartel.biz.board.dto.BoardDTO;
+import com.jangsacartel.biz.board.dto.PostUpdateRequestDTO;
 import com.jangsacartel.biz.board.service.BoardService;
+import com.jangsacartel.biz.global.jwt.filter.CustomUserDetails;
 import com.jangsacartel.biz.global.jwt.util.JwtUtil;
+import com.jangsacartel.biz.user.service.UserService;
 
 import io.jsonwebtoken.Claims;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/api")
@@ -43,6 +48,9 @@ public class BoardController {
 
 	@Autowired
 	private JwtUtil jwtUtil;
+
+	@Autowired
+	private UserService userService;
 
 	@GetMapping("/board/{postId}")
 	@ApiOperation(value="게시글 상세 조회", notes="게시글 ID로 특정 게시글의 상세 정보를 조회합니다.")
@@ -185,5 +193,38 @@ public class BoardController {
 		response.put("totalCount", totalCount);
 
 		return ResponseEntity.ok(response);
+	}
+
+	// 유저 페이지 - 게시글 수정
+	@ApiOperation(value = "게시글 수정", notes = "작성자가 자신의 게시글을 수정합니다.")
+	@PatchMapping("/board/{postId}")
+	public ResponseEntity<String> updatePost(
+		@PathVariable("postId") int postId,
+		@RequestBody PostUpdateRequestDTO requestDTO,
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		// 1. 로그인 상태 체크
+		if (userDetails == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+		}
+
+		try {
+			// 2. UserService를 통해 PK(userId) 획득
+			// UserService는 Long을 반환하므로 int로 변환 (BoardMapper가 int를 쓰기 때문)
+			Long userIdLong = userService.getUserIdByProviderId(userDetails.getProviderId());
+			int userId = userIdLong.intValue();
+
+			// 3. 수정 서비스 호출
+			boardService.updatePost(postId, userId, requestDTO);
+
+			return ResponseEntity.ok("게시글이 수정되었습니다.");
+
+		} catch (IllegalArgumentException e) {
+			// 본인 글이 아니거나 글이 없는 경우 403 Forbidden 반환
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+		} catch (Exception e) {
+			logger.error("게시글 수정 중 오류 발생", e);
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류가 발생했습니다.");
+		}
 	}
 }

--- a/src/main/java/com/jangsacartel/biz/board/dto/PostUpdateRequestDTO.java
+++ b/src/main/java/com/jangsacartel/biz/board/dto/PostUpdateRequestDTO.java
@@ -1,0 +1,19 @@
+package com.jangsacartel.biz.board.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+@ApiModel(description = "게시글 수정 요청 DTO")
+public class PostUpdateRequestDTO {
+
+	@ApiModelProperty(value = "수정할 제목", example = "제목 수정합니다", required = true)
+	private String title;
+
+	@ApiModelProperty(value = "수정할 내용", example = "내용을 수정했습니다.", required = true)
+	private String content;
+
+	@ApiModelProperty(value = "카테고리 ID (수정 시)", example = "2")
+	private int categoryId;
+}

--- a/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
+++ b/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
@@ -10,6 +10,7 @@ import com.jangsacartel.biz.board.dto.CommentDTO;
 import com.jangsacartel.biz.board.dto.FileDTO;
 import com.jangsacartel.biz.board.dto.LikeCommentDTO;
 import com.jangsacartel.biz.board.dto.LikePostDTO;
+import com.jangsacartel.biz.board.dto.PostUpdateRequestDTO;
 
 public interface BoardMapper {
 
@@ -56,4 +57,10 @@ public interface BoardMapper {
     List<BoardDTO> selectHotBoardPosts(@Param("offset") int offset, @Param("limit") int limit);
     
     int countHotBoardPosts();
+
+    // 게시글 수정 (작성자 본인 확인 기능이 포함된 수정 메서드)
+    // 리턴값 int: 수정 성공 시 1, 실패(본인 글 아님/글 없음) 시 0 반환
+    int updatePostByUser(@Param("postId") int postId,
+        @Param("userId") int userId,
+        @Param("dto") PostUpdateRequestDTO dto);
 }

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
@@ -8,6 +8,7 @@ import com.jangsacartel.biz.board.dto.CommentDTO;
 import com.jangsacartel.biz.board.dto.FileDTO;
 import com.jangsacartel.biz.board.dto.LikeCommentDTO;
 import com.jangsacartel.biz.board.dto.LikePostDTO;
+import com.jangsacartel.biz.board.dto.PostUpdateRequestDTO;
 
 public interface BoardService {
     // 게시글(Post) 관련 서비스 메서드
@@ -53,4 +54,7 @@ public interface BoardService {
     List<BoardDTO> findHotBoardPosts(int page, int pageSize);
     
     int getHotBoardPostsCount();
+
+    // 유저 페이지 - 게시글 수정
+    void updatePost(int postId, int userId, PostUpdateRequestDTO requestDTO);
 }

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.jangsacartel.biz.board.dto.BoardDTO;
 import com.jangsacartel.biz.board.dto.CategoryDTO;
@@ -11,6 +12,7 @@ import com.jangsacartel.biz.board.dto.CommentDTO;
 import com.jangsacartel.biz.board.dto.FileDTO;
 import com.jangsacartel.biz.board.dto.LikeCommentDTO;
 import com.jangsacartel.biz.board.dto.LikePostDTO;
+import com.jangsacartel.biz.board.dto.PostUpdateRequestDTO;
 import com.jangsacartel.biz.board.mapper.BoardMapper;
 
 @Service
@@ -164,5 +166,18 @@ public class BoardServiceImpl implements BoardService {
 	public int getHotBoardPostsCount() {
 		int totalCount = boardMapper.countHotBoardPosts();
 		return Math.min(totalCount, 100);
+	}
+
+	// 유저 페이지 - 게시글 수정
+	@Override
+	@Transactional
+	public void updatePost(int postId, int userId, PostUpdateRequestDTO requestDTO) {
+		// 본인 확인 및 수정 쿼리 실행
+		int result = boardMapper.updatePostByUser(postId, userId, requestDTO);
+
+		// 수정된 행이 0개라면 -> 글이 없거나, 작성자가 아님
+		if (result == 0) {
+			throw new IllegalArgumentException("게시글이 존재하지 않거나 수정 권한이 없습니다.");
+		}
 	}
 }

--- a/src/main/java/com/jangsacartel/biz/config/SecurityConfig.java
+++ b/src/main/java/com/jangsacartel/biz/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
 		config.setAllowedOrigins(List.of("http://localhost:5173")); // 프론트 주소
-		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 		config.setAllowedHeaders(List.of("*"));
 		config.setAllowCredentials(true);
 		// 클라이언트가 헤더의 토큰을 읽을 수 있게 허용

--- a/src/main/java/com/jangsacartel/biz/user/controller/UserController.java
+++ b/src/main/java/com/jangsacartel/biz/user/controller/UserController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.jangsacartel.biz.auth.dto.UserResponseDTO;
 import com.jangsacartel.biz.auth.service.KakaoAuthService;
 import com.jangsacartel.biz.global.jwt.filter.CustomUserDetails;
+import com.jangsacartel.biz.user.dto.MyCommentDTO;
 import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
 import com.jangsacartel.biz.user.dto.MyPostDTO;
 import com.jangsacartel.biz.user.dto.NicknameUpdateRequestDTO;
@@ -33,7 +34,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-
 @Api(tags = "유저 컨트롤러")
 public class UserController {
 
@@ -133,6 +133,34 @@ public class UserController {
 		userService.deletePost(userId, postId);
 
 		return ResponseEntity.ok("게시글이 삭제되었습니다.");
+	}
+
+	// 내가 쓴 댓글 조회
+	@ApiOperation(value = "내가 쓴 댓글 조회")
+	@GetMapping("/comments")
+	public ResponseEntity<List<MyCommentDTO>> getMyComments(
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		// 토큰에서 ID 추출
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		// 데이터 반환
+		return ResponseEntity.ok(userService.getMyComments(userId));
+	}
+
+	// 내가 좋아요한 글 조회
+	@ApiOperation(value = "좋아요한 게시글 조회")
+	@GetMapping("/likes")
+	public ResponseEntity<List<MyPostDTO>> getMyLikedPosts(
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		return ResponseEntity.ok(userService.getMyLikedPosts(userId));
 	}
 
 }

--- a/src/main/java/com/jangsacartel/biz/user/controller/UserController.java
+++ b/src/main/java/com/jangsacartel/biz/user/controller/UserController.java
@@ -1,8 +1,14 @@
 package com.jangsacartel.biz.user.controller;
 
+import java.util.List;
+
 import com.jangsacartel.biz.auth.dto.UserResponseDTO;
 import com.jangsacartel.biz.auth.service.KakaoAuthService;
 import com.jangsacartel.biz.global.jwt.filter.CustomUserDetails;
+import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
+import com.jangsacartel.biz.user.dto.MyPostDTO;
+import com.jangsacartel.biz.user.dto.NicknameUpdateRequestDTO;
+import com.jangsacartel.biz.user.service.UserService;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -15,7 +21,11 @@ import springfox.documentation.annotations.ApiIgnore;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,10 +38,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
 	private final KakaoAuthService kakaoAuthService;
+	private final UserService userService;
 
 	// 내 정보 조회
 	// 요청 주소: GET /api/users
-	
 	@ApiOperation(
             value = "내 정보 조회",
             notes =
@@ -48,7 +58,7 @@ public class UserController {
 	public ResponseEntity<UserResponseDTO> getUserInfo(
 			@ApiIgnore
 			@AuthenticationPrincipal CustomUserDetails userDetails) {
-		
+
 		// [추가된 안전장치] 토큰 없이 들어왔을 경우 방어
 		if (userDetails == null) {
 			log.warn("❌ [Controller] 인증되지 않은 사용자의 접근입니다.");
@@ -61,6 +71,68 @@ public class UserController {
 		UserResponseDTO userInfo = kakaoAuthService.getUserInfoByProviderId(providerId);
 
 		return ResponseEntity.ok(userInfo);
+	}
+
+	// 마이페이지 닉네임/상호명/지역 조회 - UserService 사용
+	@ApiOperation(value = "마이페이지 프로필 조회", notes = "마이페이지용 정보(닉네임, 상호명, 지역)를 조회합니다.")
+	@GetMapping("/mypage")
+	public ResponseEntity<MyPageProfileResponseDTO> getMyPageInfo(
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		// UserService를 통해 PK(userId) 획득
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		return ResponseEntity.ok(userService.getMyPageProfile(userId));
+	}
+
+	// 마이페이지 닉네임 수정 - UserService 사용
+	@ApiOperation(value = "닉네임 수정", notes = "유저의 닉네임을 수정합니다.")
+	@PatchMapping("/nickname")
+	public ResponseEntity<String> updateNickname(
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody NicknameUpdateRequestDTO requestDTO) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		// UserService를 통해 PK(userId) 획득
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		userService.updateNickname(userId, requestDTO.getNickname());
+
+		return ResponseEntity.ok("닉네임이 수정되었습니다.");
+	}
+
+	// 마이페이지 내가 쓴 게시글 조회 - UserService 사용
+	@ApiOperation(value = "내가 쓴 게시글 조회", notes = "작성한 게시글 목록을 반환합니다.")
+	@GetMapping("/posts")
+	public ResponseEntity<List<MyPostDTO>> getMyPosts(
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		// UserService를 통해 PK(userId) 획득
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		return ResponseEntity.ok(userService.getMyPosts(userId));
+	}
+
+	// 마이페이지 내 게시글 삭제 - UserService 사용
+	@ApiOperation(value = "내 게시글 삭제", notes = "게시글 ID를 받아 삭제(Soft Delete) 처리합니다.")
+	@DeleteMapping("/posts/{postId}")
+	public ResponseEntity<String> deleteMyPost(
+		@PathVariable Long postId,
+		@ApiIgnore @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		if (userDetails == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+		// UserService를 통해 PK(userId) 획득
+		Long userId = userService.getUserIdByProviderId(userDetails.getProviderId());
+
+		userService.deletePost(userId, postId);
+
+		return ResponseEntity.ok("게시글이 삭제되었습니다.");
 	}
 
 }

--- a/src/main/java/com/jangsacartel/biz/user/dto/MyCommentDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/MyCommentDTO.java
@@ -1,0 +1,15 @@
+package com.jangsacartel.biz.user.dto;
+
+import lombok.Data;
+import java.util.Date;
+
+@Data
+public class MyCommentDTO {
+	private Long commentId;
+	private String content;   // 댓글 내용
+	private Date createdAt;   // 작성일
+
+	// 조인해서 가져올 게시글 정보
+	private Long postId;
+	private String postTitle;
+}

--- a/src/main/java/com/jangsacartel/biz/user/dto/MyPageProfileResponseDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/MyPageProfileResponseDTO.java
@@ -1,0 +1,28 @@
+package com.jangsacartel.biz.user.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "마이페이지 프로필 조회 응답")
+public class MyPageProfileResponseDTO {
+
+	@ApiModelProperty(value = "유저 ID (PK)", example = "1")
+	private Long userId;
+
+	@ApiModelProperty(value = "닉네임", example = "장사왕")
+	private String nickname;
+
+	@ApiModelProperty(value = "가게 상호명", example = "대박난가게")
+	private String userStoreName;
+
+	@ApiModelProperty(value = "지역", example = "충남 부여")
+	private String region;
+}

--- a/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
@@ -11,4 +11,6 @@ public class MyPostDTO {
 	private String title;
 	private Date createdAt;
 	private String categoryName;
+	private Long likeCount;
+	private Long commentCount;
 }

--- a/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
@@ -1,0 +1,14 @@
+package com.jangsacartel.biz.user.dto;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@ApiModel(description = "내가 쓴 게시글 정보")
+public class MyPostDTO {
+	private Long postId;
+	private String title;
+	private LocalDateTime createdAt;
+	private String categoryName;
+}

--- a/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/MyPostDTO.java
@@ -2,13 +2,13 @@ package com.jangsacartel.biz.user.dto;
 
 import io.swagger.annotations.ApiModel;
 import lombok.Data;
-import java.time.LocalDateTime;
+import java.util.Date;
 
 @Data
 @ApiModel(description = "내가 쓴 게시글 정보")
 public class MyPostDTO {
 	private Long postId;
 	private String title;
-	private LocalDateTime createdAt;
+	private Date createdAt;
 	private String categoryName;
 }

--- a/src/main/java/com/jangsacartel/biz/user/dto/NicknameUpdateRequestDTO.java
+++ b/src/main/java/com/jangsacartel/biz/user/dto/NicknameUpdateRequestDTO.java
@@ -1,0 +1,14 @@
+package com.jangsacartel.biz.user.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+@ApiModel(description = "닉네임 수정 요청")
+public class NicknameUpdateRequestDTO {
+
+	@ApiModelProperty(value = "변경할 닉네임", example = "새로운닉네임", required = true)
+	private String nickname;
+
+}

--- a/src/main/java/com/jangsacartel/biz/user/mapper/UserMapper.java
+++ b/src/main/java/com/jangsacartel/biz/user/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.jangsacartel.biz.user.mapper;
 
 import java.util.List;
 
+import com.jangsacartel.biz.user.dto.MyCommentDTO;
 import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
 import com.jangsacartel.biz.user.dto.MyPostDTO;
 import com.jangsacartel.biz.user.entity.UserVO;
@@ -44,4 +45,10 @@ public interface UserMapper {
 
 	// 마이페이지 게시글 삭제
 	void deletePost(@Param("postId") Long postId, @Param("userId") Long userId);
+
+	// 내가 쓴 댓글
+	List<MyCommentDTO> findCommentsByUserId(Long userId);
+
+	// 내가 좋아요한 글
+	List<MyPostDTO> findLikedPostsByUserId(Long userId);
 }

--- a/src/main/java/com/jangsacartel/biz/user/mapper/UserMapper.java
+++ b/src/main/java/com/jangsacartel/biz/user/mapper/UserMapper.java
@@ -1,5 +1,9 @@
 package com.jangsacartel.biz.user.mapper;
 
+import java.util.List;
+
+import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
+import com.jangsacartel.biz.user.dto.MyPostDTO;
 import com.jangsacartel.biz.user.entity.UserVO;
 import com.jangsacartel.biz.user.entity.UserInfoVO;
 
@@ -28,4 +32,16 @@ public interface UserMapper {
 
 	// 사업자 번호 중복 확인 (파라미터는 int)
 	boolean existsByBusinessRegNo(Integer businessRegNo);
+
+	// 마이페이지 프로필 조회
+	MyPageProfileResponseDTO findProfileByUserId(Long userId);
+
+	// 마이페이지 닉네임 수정
+	void updateNickname(@Param("userId") Long userId, @Param("nickname") String nickname);
+
+	// 마이페이지 내가 쓴 게시글 조회
+	List<MyPostDTO> findPostsByUserId(Long userId);
+
+	// 마이페이지 게시글 삭제
+	void deletePost(@Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/jangsacartel/biz/user/service/UserService.java
+++ b/src/main/java/com/jangsacartel/biz/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.jangsacartel.biz.user.service;
 
+import com.jangsacartel.biz.user.dto.MyCommentDTO;
 import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
 import com.jangsacartel.biz.user.dto.MyPostDTO;
 import com.jangsacartel.biz.user.entity.UserVO;
@@ -51,6 +52,18 @@ public class UserService {
 			throw new IllegalArgumentException("존재하지 않는 회원입니다.");
 		}
 		return user.getUserId();
+	}
+
+	// 내가 쓴 댓글 가져오기
+	@Transactional(readOnly = true)
+	public List<MyCommentDTO> getMyComments(Long userId) {
+		return userMapper.findCommentsByUserId(userId);
+	}
+
+	// 내가 좋아요한 글 가져오기
+	@Transactional(readOnly = true)
+	public List<MyPostDTO> getMyLikedPosts(Long userId) {
+		return userMapper.findLikedPostsByUserId(userId);
 	}
 
 }

--- a/src/main/java/com/jangsacartel/biz/user/service/UserService.java
+++ b/src/main/java/com/jangsacartel/biz/user/service/UserService.java
@@ -1,0 +1,56 @@
+package com.jangsacartel.biz.user.service;
+
+import com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO;
+import com.jangsacartel.biz.user.dto.MyPostDTO;
+import com.jangsacartel.biz.user.entity.UserVO;
+import com.jangsacartel.biz.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserMapper userMapper;
+
+	// 프로필 조회
+	@Transactional(readOnly = true)
+	public MyPageProfileResponseDTO getMyPageProfile(Long userId) {
+		return userMapper.findProfileByUserId(userId);
+	}
+
+	// 닉네임 수정
+	@Transactional
+	public void updateNickname(Long userId, String newNickname) {
+		userMapper.updateNickname(userId, newNickname);
+	}
+
+	// 내 게시글 목록 조회
+	@Transactional(readOnly = true)
+	public List<MyPostDTO> getMyPosts(Long userId) {
+		return userMapper.findPostsByUserId(userId);
+	}
+
+	// 게시글 삭제
+	@Transactional
+	public void deletePost(Long userId, Long postId) {
+		userMapper.deletePost(postId, userId);
+	}
+
+	// ProviderId(소셜 ID)로 User ID(DB PK) 조회
+	@Transactional(readOnly = true)
+	public Long getUserIdByProviderId(String providerId) {
+		// "kakao"는 고정값이거나 파라미터로 받을 수 있다.
+		// 현재 로직상 KakaoAuthService가 "kakao"로 저장하므로 "kakao"로 조회합니다.
+		UserVO user = userMapper.findByProviderAndProviderId("kakao", providerId);
+		if (user == null) {
+			throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+		}
+		return user.getUserId();
+	}
+
+}

--- a/src/main/resources/mapper/board/BoardMapper.xml
+++ b/src/main/resources/mapper/board/BoardMapper.xml
@@ -196,4 +196,13 @@
             deleted_at IS NULL
     </select>
 
+    <update id="updatePostByUser">
+        UPDATE Post
+        SET title = #{dto.title},
+            content = #{dto.content},
+            category_id = #{dto.categoryId},
+            modified_at = NOW()
+        WHERE post_id = #{postId}
+          AND user_id = #{userId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -48,4 +48,40 @@
         FROM User_Info
         WHERE business_reg_no = #{businessRegNo}
     </select>
+
+    <select id="findProfileByUserId" resultType="com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO">
+        SELECT
+            u.user_id AS userId,
+            u.nickname AS nickname,
+            ui.user_storeName AS userStoreName,
+            ui.region AS region
+        FROM User u
+                 LEFT JOIN User_Info ui ON u.user_id = ui.user_id
+        WHERE u.user_id = #{userId}
+    </select>
+
+    <update id="updateNickname">
+        UPDATE User
+        SET nickname = #{nickname}
+        WHERE user_id = #{userId}
+    </update>
+
+    <select id="findPostsByUserId" resultType="com.jangsacartel.biz.user.dto.MyPostDTO">
+        SELECT
+            p.post_id      AS postId,
+            p.title        AS title,
+            p.created_at   AS createdAt,
+            c.name         AS categoryName
+        FROM `게시글` p
+                 JOIN `게시판 카테고리` c ON p.category_id = c.category_id
+        WHERE p.user_id = #{userId}
+          AND p.deleted_at IS NULL
+        ORDER BY p.created_at DESC
+    </select>
+
+    <update id="deletePost">
+        UPDATE `게시글`
+        SET deleted_at = NOW()
+        WHERE post_id = #{postId} AND user_id = #{userId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -27,7 +27,9 @@
             p.post_id      AS postId,
             p.title        AS title,
             p.created_at   AS createdAt,
-            c.name         AS categoryName
+            c.name         AS categoryName,
+            (SELECT COUNT(*) FROM Like_Post WHERE post_id = p.post_id) AS likeCount,
+            (SELECT COUNT(*) FROM Comment WHERE post_id = p.post_id AND deleted_at IS NULL) AS commentCount
         FROM Post p
                  JOIN Category c ON p.category_id = c.category_id
         WHERE p.user_id = #{userId}
@@ -106,7 +108,9 @@
             p.post_id      AS postId,
             p.title        AS title,
             p.created_at   AS createdAt,
-            cat.name       AS categoryName
+            cat.name       AS categoryName,
+            (SELECT COUNT(*) FROM Like_Post WHERE post_id = p.post_id) AS likeCount,
+            (SELECT COUNT(*) FROM Comment WHERE post_id = p.post_id AND deleted_at IS NULL) AS commentCount
         FROM Like_Post lp
                  JOIN Post p ON lp.post_id = p.post_id
                  JOIN Category cat ON p.category_id = cat.category_id

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -1,9 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper
-    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.jangsacartel.biz.user.mapper.UserMapper">
+
+    <select id="findProfileByUserId" resultType="com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO">
+        SELECT
+            u.user_id AS userId,
+            u.nickname AS nickname,
+            ui.user_storeName AS userStoreName,
+            ui.region AS region
+        FROM User u
+                 LEFT JOIN User_Info ui ON u.user_id = ui.user_id
+        WHERE u.user_id = #{userId}
+    </select>
+
+    <update id="updateNickname">
+        UPDATE User
+        SET nickname = #{nickname}
+        WHERE user_id = #{userId}
+    </update>
+
+    <select id="findPostsByUserId" resultType="com.jangsacartel.biz.user.dto.MyPostDTO">
+        SELECT
+            p.post_id      AS postId,
+            p.title        AS title,
+            p.created_at   AS createdAt,
+            c.name         AS categoryName
+        FROM Post p
+                 JOIN Category c ON p.category_id = c.category_id
+        WHERE p.user_id = #{userId}
+          AND p.deleted_at IS NULL
+        ORDER BY p.created_at DESC
+    </select>
+
+    <update id="deletePost">
+        UPDATE Post
+        SET deleted_at = NOW()
+        WHERE post_id = #{postId} AND user_id = #{userId}
+    </update>
+
+
     <select id="getTime" resultType="string">
         SELECT NOW()
     </select>
@@ -49,39 +87,4 @@
         WHERE business_reg_no = #{businessRegNo}
     </select>
 
-    <select id="findProfileByUserId" resultType="com.jangsacartel.biz.user.dto.MyPageProfileResponseDTO">
-        SELECT
-            u.user_id AS userId,
-            u.nickname AS nickname,
-            ui.user_storeName AS userStoreName,
-            ui.region AS region
-        FROM User u
-                 LEFT JOIN User_Info ui ON u.user_id = ui.user_id
-        WHERE u.user_id = #{userId}
-    </select>
-
-    <update id="updateNickname">
-        UPDATE User
-        SET nickname = #{nickname}
-        WHERE user_id = #{userId}
-    </update>
-
-    <select id="findPostsByUserId" resultType="com.jangsacartel.biz.user.dto.MyPostDTO">
-        SELECT
-            p.post_id      AS postId,
-            p.title        AS title,
-            p.created_at   AS createdAt,
-            c.name         AS categoryName
-        FROM `게시글` p
-                 JOIN `게시판 카테고리` c ON p.category_id = c.category_id
-        WHERE p.user_id = #{userId}
-          AND p.deleted_at IS NULL
-        ORDER BY p.created_at DESC
-    </select>
-
-    <update id="deletePost">
-        UPDATE `게시글`
-        SET deleted_at = NOW()
-        WHERE post_id = #{postId} AND user_id = #{userId}
-    </update>
 </mapper>

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -87,4 +87,32 @@
         WHERE business_reg_no = #{businessRegNo}
     </select>
 
+    <select id="findCommentsByUserId" resultType="com.jangsacartel.biz.user.dto.MyCommentDTO">
+        SELECT
+            c.comment_id   AS commentId,
+            c.content      AS content,
+            c.created_at   AS createdAt,
+            c.post_id      AS postId,
+            p.title        AS postTitle
+        FROM Comment c
+                 JOIN Post p ON c.post_id = p.post_id
+        WHERE c.user_id = #{userId}
+          AND c.deleted_at IS NULL
+        ORDER BY c.created_at DESC
+    </select>
+
+    <select id="findLikedPostsByUserId" resultType="com.jangsacartel.biz.user.dto.MyPostDTO">
+        SELECT
+            p.post_id      AS postId,
+            p.title        AS title,
+            p.created_at   AS createdAt,
+            cat.name       AS categoryName
+        FROM Like_Post lp
+                 JOIN Post p ON lp.post_id = p.post_id
+                 JOIN Category cat ON p.category_id = cat.category_id
+        WHERE lp.user_id = #{userId}
+          AND p.deleted_at IS NULL
+        ORDER BY lp.post_id DESC
+    </select>
+
 </mapper>


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #23 

### ✅ 작업한 내용

### 1. 유저 정보 관리 (User Profile)
- **유저 정보 조회 (READ)**
  - 로그인한 사용자의 **닉네임, 상호명, 지역 정보**를 조회하여 반환하는 로직을 구현했습니다.
  - JWT 토큰을 통해 사용자 인증 및 식별을 수행합니다.
- **유저 정보 수정 (UPDATE)**
  - **닉네임 변경 기능**을 구현했습니다. (중복 검사 및 업데이트 로직 포함)

### 2. 내가 작성한 글 관리 (My Posts)
- **작성 글 목록 조회 (READ)**
  - 사용자가 작성한 게시글 리스트를 불러옵니다.
  - 목록에는 **게시글 종류(카테고리), 제목, 좋아요 수, 댓글 수, 게시 날짜** 정보가 포함되도록 DTO를 구성했습니다.
- **게시글 수정 (UPDATE)**
  - 본인이 작성한 게시글에 한하여 내용을 수정할 수 있는 기능을 구현했습니다.
- **게시글 삭제 (DELETE)**
  - 본인이 작성한 게시글을 삭제할 수 있는 기능을 구현했습니다. (작성자 검증 로직 포함)

### ❗️PR Point

### 📝 미구현 사항 (To-Do)
1. **내가 작성한 댓글 관리 섹션**
   - 내가 쓴 댓글 목록 조회, 수정, 삭제 기능은 아직 구현되지 않았습니다.
2. **유저 정보 추가 수정**
   - 현재는 닉네임만 변경 가능하며, **지역**과 **상호명**을 변경하는 기능은 추가 구현이 필요합니다.
3. **회원 탈퇴**
   - 회원 탈퇴(계정 삭제) 버튼 및 관련 백엔드 로직이 아직 구현되지 않았습니다.

### 📸 스크린샷

<!-- 스크린 샷이 있다면 첨부해주세요 -->

closed #23 
