### PR TITLE
✨ Feat : 지역게시판 필터링 구현

### DIFF
--- a/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
+++ b/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
@@ -181,8 +181,8 @@ public class BoardController {
 	})
     @ApiResponse(code = 200, message = "Successfully retrieved free board posts", response = BoardListResponseDTO.class)
 	public ResponseEntity<BoardListResponseDTO> getFreeBoardPage(@RequestParam(defaultValue = "1") int page) {
-		List<BoardDTO> freeBoardPosts = boardService.findPostsByCategory(2, page, 4);
-		int totalCount = boardService.countPostsByCategory(2);
+		List<BoardDTO> freeBoardPosts = boardService.findPostsByCategory(2, page, 4, null);
+		int totalCount = boardService.countPostsByCategory(2, null);
 		
         BoardListResponseDTO response = new BoardListResponseDTO(freeBoardPosts, totalCount);
 		
@@ -196,8 +196,8 @@ public class BoardController {
 	})
     @ApiResponse(code = 200, message = "Successfully retrieved info board posts", response = BoardListResponseDTO.class)
 	public ResponseEntity<BoardListResponseDTO> getInfoBoardPage(@RequestParam(defaultValue = "1") int page) {
-		List<BoardDTO> infoBoardPosts = boardService.findPostsByCategory(3, page, 4);
-		int totalCount = boardService.countPostsByCategory(3);
+		List<BoardDTO> infoBoardPosts = boardService.findPostsByCategory(3, page, 4, null);
+		int totalCount = boardService.countPostsByCategory(3, null);
 
         BoardListResponseDTO response = new BoardListResponseDTO(infoBoardPosts, totalCount);
 		
@@ -207,12 +207,15 @@ public class BoardController {
 	@GetMapping("/local")
 	@ApiOperation(value = "지역 게시판", notes = "지역 게시판의 게시글 목록을 조회합니다.")
 	@ApiImplicitParams({
-		@ApiImplicitParam(name = "page", value = "페이지 번호", dataType = "int", paramType = "query", defaultValue = "1", example = "1")
+		@ApiImplicitParam(name = "page", value = "페이지 번호", dataType = "int", paramType = "query", defaultValue = "1", example = "1"),
+		@ApiImplicitParam(name = "region", value = "지역 필터 (예: '서울특별시 강남구 역삼동')", dataType = "string", paramType = "query")
 	})
     @ApiResponse(code = 200, message = "Successfully retrieved local board posts", response = BoardListResponseDTO.class)
-	public ResponseEntity<BoardListResponseDTO> getLocalBoardPage(@RequestParam(defaultValue = "1") int page) {
-		List<BoardDTO> localBoardPosts = boardService.findPostsByCategory(4, page, 4);
-		int totalCount = boardService.countPostsByCategory(4);
+	public ResponseEntity<BoardListResponseDTO> getLocalBoardPage(
+			@RequestParam(defaultValue = "1") int page,
+			@RequestParam(required = false) String region) {
+		List<BoardDTO> localBoardPosts = boardService.findPostsByCategory(4, page, 4, region);
+		int totalCount = boardService.countPostsByCategory(4, region);
 		
 		BoardListResponseDTO response = new BoardListResponseDTO(localBoardPosts, totalCount);
 

--- a/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
+++ b/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
@@ -52,9 +52,9 @@ public interface BoardMapper {
     
     List<BoardDTO> findRecentPosts(@Param("categoryId") int categoryId, @Param("limit") int limit);
     
-    List<BoardDTO> findPostsByCategory(@Param("categoryId") int categoryId, @Param("offset") int offset, @Param("limit") int limit);
+    List<BoardDTO> findPostsByCategory(@Param("categoryId") int categoryId, @Param("offset") int offset, @Param("limit") int limit, @Param("region") String region);
     
-    int countPostsByCategory(@Param("categoryId") int categoryId);
+    int countPostsByCategory(@Param("categoryId") int categoryId, @Param("region") String region);
     
     List<BoardDTO> selectHotBoardPosts(@Param("offset") int offset, @Param("limit") int limit);
     

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
@@ -47,9 +47,9 @@ public interface BoardService {
     
     List<BoardDTO> findRecentPosts(int categoryId, int limit);
     
-    List<BoardDTO> findPostsByCategory(int categoryId, int page, int pageSize);
+    List<BoardDTO> findPostsByCategory(int categoryId, int page, int pageSize, String region);
     
-    int countPostsByCategory(int categoryId);
+    int countPostsByCategory(int categoryId, String region);
     
     List<BoardDTO> findHotBoardPosts(int page, int pageSize);
     

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
@@ -146,14 +146,14 @@ public class BoardServiceImpl implements BoardService {
 	}
 
 	@Override
-	public List<BoardDTO> findPostsByCategory(int categoryId, int page, int pageSize) {
+	public List<BoardDTO> findPostsByCategory(int categoryId, int page, int pageSize, String region) {
 		int offset = (page - 1) * pageSize;
-		return boardMapper.findPostsByCategory(categoryId, offset, pageSize);
+		return boardMapper.findPostsByCategory(categoryId, offset, pageSize, region);
 	}
 
 	@Override
-	public int countPostsByCategory(int categoryId) {
-		return boardMapper.countPostsByCategory(categoryId);
+	public int countPostsByCategory(int categoryId, String region) {
+		return boardMapper.countPostsByCategory(categoryId, region);
 	}
 
 	@Override

--- a/src/main/resources/mapper/board/BoardMapper.xml
+++ b/src/main/resources/mapper/board/BoardMapper.xml
@@ -191,12 +191,18 @@
             SUBSTRING(p.content, 1, 20) as content,
             p.created_at,
             (SELECT COUNT(*) FROM Like_Post WHERE post_id = p.post_id) as like_count,
-            (SELECT COUNT(*) FROM Comment WHERE post_id = p.post_id AND deleted_at IS NULL) as comment_count
+            (SELECT COUNT(*) FROM Comment WHERE post_id = p.post_id AND deleted_at IS NULL) as comment_count,
+            ui.region
         FROM
             Post p
+        JOIN
+            User_Info ui ON p.user_id = ui.user_id
         WHERE
             p.category_id = #{categoryId}
           AND p.deleted_at IS NULL
+          <if test="region != null and region != ''">
+              AND ui.region = #{region}
+          </if>
         ORDER BY
             p.created_at DESC
         LIMIT #{limit} OFFSET #{offset}
@@ -206,10 +212,15 @@
         SELECT
             COUNT(*)
         FROM
-            Post
+            Post p
+        JOIN
+            User_Info ui ON p.user_id = ui.user_id
         WHERE
-            category_id = #{categoryId}
-          AND deleted_at IS NULL
+            p.category_id = #{categoryId}
+            AND p.deleted_at IS NULL
+            <if test="region != null and region != ''">
+                AND ui.region = #{region}
+            </if>
     </select>
     
     <select id="selectHotBoardPosts" resultType="com.jangsacartel.biz.board.dto.BoardDTO">


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 #39 
- #39 

### ✅ 작업한 내용

- 지역게시판 내 필터 버튼을 통해 지역별 필터, 해당 지역의 유저가 쓴 글들만 보이도록 필터링 

### ❗️PR Point

- 초기화 버튼을 통해 필터가 없던 상황으로 되돌리기 가능
- 게시판 첫 진입시 필터가 없는 상태로 모든 글이 뜨는것은 정상상태 (의도한 대로)
- 필터 후 해당 지역의 글만 뜨는지 확인 (DB 데이터 값을 통해 해당 유저가 속한 지역을 확인하면서 테스트 진행)

### 📸 스크린샷

<img width="437" height="885" alt="image" src="https://github.com/user-attachments/assets/ac3a3899-08ba-4ae1-88da-1008e84d658b" />

closed #39 
