### PR TITLE
✨ Feat : 지도를 통한 local게시판 필터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,10 @@ dependencies {
     implementation 'commons-fileupload:commons-fileupload:1.5'
     implementation 'commons-io:commons-io:2.15.1'
 
+    /* Geometry/Spatial */
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+    implementation 'org.wololo:jts2geojson:0.18.1'
+
     /* Test */
     testImplementation "org.springframework:spring-test:${springVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"

--- a/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
+++ b/src/main/java/com/jangsacartel/biz/board/controller/BoardController.java
@@ -222,6 +222,17 @@ public class BoardController {
 		return ResponseEntity.ok(response);
 	}
 
+    @GetMapping("/board/hot-by-region")
+    @ApiOperation(value = "지역별 인기 게시글 조회", notes = "특정 지역의 인기 게시글을 조회합니다. (최대 3개)")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "region", value = "지역 필터 (예: '서울특별시 강남구')", dataType = "string", paramType = "query", required = false)
+    })
+    @ApiResponse(code = 200, message = "Successfully retrieved hot posts by region", response = BoardDTO.class, responseContainer = "List")
+    public ResponseEntity<List<BoardDTO>> getHotPostsByRegion(@RequestParam(required = false) String region) {
+        List<BoardDTO> hotPosts = boardService.findHotPostsByRegion(region, 3); // Limit to 3 as requested
+        return ResponseEntity.ok(hotPosts);
+    }
+
 	// 유저 페이지 - 게시글 수정
 	@ApiOperation(value = "게시글 수정", notes = "작성자가 자신의 게시글을 수정합니다.")
 	@PatchMapping("/board/{postId}")

--- a/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
+++ b/src/main/java/com/jangsacartel/biz/board/mapper/BoardMapper.java
@@ -58,6 +58,8 @@ public interface BoardMapper {
     
     List<BoardDTO> selectHotBoardPosts(@Param("offset") int offset, @Param("limit") int limit);
     
+    List<BoardDTO> findHotPostsByRegion(@Param("region") String region, @Param("limit") int limit);
+    
     int countHotBoardPosts();
 
     // 게시글 수정 (작성자 본인 확인 기능이 포함된 수정 메서드)

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardService.java
@@ -53,6 +53,8 @@ public interface BoardService {
     
     List<BoardDTO> findHotBoardPosts(int page, int pageSize);
     
+    List<BoardDTO> findHotPostsByRegion(String region, int limit);
+    
     int getHotBoardPostsCount();
 
     // 유저 페이지 - 게시글 수정

--- a/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/board/service/BoardServiceImpl.java
@@ -168,6 +168,11 @@ public class BoardServiceImpl implements BoardService {
 		return Math.min(totalCount, 100);
 	}
 
+    @Override
+    public List<BoardDTO> findHotPostsByRegion(String region, int limit) {
+        return boardMapper.findHotPostsByRegion(region, limit);
+    }
+
 	// 유저 페이지 - 게시글 수정
 	@Override
 	@Transactional

--- a/src/main/java/com/jangsacartel/biz/config/SecurityConfig.java
+++ b/src/main/java/com/jangsacartel/biz/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 			.formLogin().disable()
 			.httpBasic().disable()
 			.authorizeHttpRequests(auth -> auth
-				    .requestMatchers("/api/auth/**", "/api/kakao/**").permitAll()
+				    .requestMatchers("/api/auth/**", "/api/kakao/**", "/api/map/**").permitAll()
 				    .requestMatchers(
 				            "/swagger-ui.html",
 				            "/v2/api-docs",

--- a/src/main/java/com/jangsacartel/biz/map/controller/MapController.java
+++ b/src/main/java/com/jangsacartel/biz/map/controller/MapController.java
@@ -1,0 +1,37 @@
+package com.jangsacartel.biz.map.controller;
+
+import com.jangsacartel.biz.map.dto.KakaoMapApiKeyResponse;
+import com.jangsacartel.biz.map.service.GeoDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/map")
+public class MapController {
+
+    @Value("${kakao.map.api}")
+    private String kakaoMapApiKey;
+
+    @Autowired
+    private GeoDataService geoDataService;
+
+    @GetMapping("/key")
+    public KakaoMapApiKeyResponse getKakaoMapApiKey() {
+        return new KakaoMapApiKeyResponse(kakaoMapApiKey);
+    }
+
+    @GetMapping("/boundaries")
+    public ResponseEntity<Map<String, Object>> getBoundaries(
+            @RequestParam double minLat, @RequestParam double minLng,
+            @RequestParam double maxLat, @RequestParam double maxLng) {
+        Map<String, Object> featureCollectionMap = geoDataService.findIntersectingFeatures(minLat, minLng, maxLat, maxLng);
+        return ResponseEntity.ok(featureCollectionMap);
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/map/dto/KakaoMapApiKeyResponse.java
+++ b/src/main/java/com/jangsacartel/biz/map/dto/KakaoMapApiKeyResponse.java
@@ -1,0 +1,12 @@
+package com.jangsacartel.biz.map.dto;
+
+import lombok.Data;
+
+@Data
+public class KakaoMapApiKeyResponse {
+    private String kakaoMapApiKey;
+
+    public KakaoMapApiKeyResponse(String kakaoMapApiKey) {
+        this.kakaoMapApiKey = kakaoMapApiKey;
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/map/dto/MapDTO.java
+++ b/src/main/java/com/jangsacartel/biz/map/dto/MapDTO.java
@@ -1,0 +1,4 @@
+package com.jangsacartel.biz.map.dto;
+
+public class MapDTO {
+}

--- a/src/main/java/com/jangsacartel/biz/map/mapper/MapMapper.java
+++ b/src/main/java/com/jangsacartel/biz/map/mapper/MapMapper.java
@@ -1,0 +1,7 @@
+package com.jangsacartel.biz.map.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MapMapper {
+}

--- a/src/main/java/com/jangsacartel/biz/map/service/GeoDataService.java
+++ b/src/main/java/com/jangsacartel/biz/map/service/GeoDataService.java
@@ -1,0 +1,116 @@
+package com.jangsacartel.biz.map.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.LinearRing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class GeoDataService {
+
+    private static final Logger logger = LoggerFactory.getLogger(GeoDataService.class);
+    private List<Map<String, Object>> allFeatures;
+
+    @PostConstruct
+    @SuppressWarnings("unchecked")
+    public void loadGeoJsonData() {
+        logger.info("Loading GeoJSON data for administrative districts...");
+        try (InputStream inputStream = new ClassPathResource("data/HangJeongDong_ver20250401.geojson").getInputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, Object> featureCollectionMap = objectMapper.readValue(inputStream, new TypeReference<Map<String, Object>>() {});
+            this.allFeatures = (List<Map<String, Object>>) featureCollectionMap.get("features");
+            logger.info("Successfully loaded {} features.", allFeatures.size());
+        } catch (Exception e) {
+            logger.error("Failed to load or parse GeoJSON file.", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> findIntersectingFeatures(double minLat, double minLng, double maxLat, double maxLng) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("type", "FeatureCollection");
+
+        if (allFeatures == null) {
+            logger.warn("GeoJSON features not loaded. Returning empty collection.");
+            result.put("features", new ArrayList<>());
+            return result;
+        }
+
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate[] coords = new Coordinate[] {
+                new Coordinate(minLng, minLat), new Coordinate(maxLng, minLat),
+                new Coordinate(maxLng, maxLat), new Coordinate(minLng, maxLat),
+                new Coordinate(minLng, minLat)
+        };
+        Polygon requestBounds = geometryFactory.createPolygon(coords);
+
+        List<Map<String, Object>> intersectingFeatures = allFeatures.parallelStream()
+                .filter(feature -> {
+                    Map<String, Object> geometryMap = (Map<String, Object>) feature.get("geometry");
+                    if (geometryMap == null) return false;
+
+                    try {
+                        Geometry featureGeometry = createGeometryFromMap(geometryMap, geometryFactory);
+                        return requestBounds.intersects(featureGeometry);
+                    } catch (Exception e) {
+                        
+                        return false;
+                    }
+                })
+                .collect(Collectors.toList());
+
+        result.put("features", intersectingFeatures);
+        return result;
+    }
+    
+    @SuppressWarnings("unchecked")
+    private Geometry createGeometryFromMap(Map<String, Object> geometryMap, GeometryFactory factory) {
+        String type = (String) geometryMap.get("type");
+        List<?> coordinates = (List<?>) geometryMap.get("coordinates");
+
+        if ("Polygon".equalsIgnoreCase(type)) {
+            List<List<List<Double>>> polygonCoords = (List<List<List<Double>>>) coordinates;
+            return createPolygon(polygonCoords, factory);
+        } else if ("MultiPolygon".equalsIgnoreCase(type)) {
+            List<List<List<List<Double>>>> multiPolygonCoords = (List<List<List<List<Double>>>>) coordinates;
+            Polygon[] polygons = multiPolygonCoords.stream()
+                    .map(polygonCoords -> createPolygon(polygonCoords, factory))
+                    .toArray(Polygon[]::new);
+            return factory.createMultiPolygon(polygons);
+        }
+        return null;
+    }
+
+    private Polygon createPolygon(List<List<List<Double>>> polygonCoords, GeometryFactory factory) {
+        List<Double> shellCoords = polygonCoords.get(0).get(0);
+        LinearRing shell = factory.createLinearRing(getCoordinates(polygonCoords.get(0)));
+        
+        LinearRing[] holes = new LinearRing[polygonCoords.size() - 1];
+        for (int i = 1; i < polygonCoords.size(); i++) {
+            holes[i - 1] = factory.createLinearRing(getCoordinates(polygonCoords.get(i)));
+        }
+        
+        return factory.createPolygon(shell, holes);
+    }
+
+    private Coordinate[] getCoordinates(List<List<Double>> coordsList) {
+        return coordsList.stream()
+                         .map(c -> new Coordinate(c.get(0), c.get(1)))
+                         .toArray(Coordinate[]::new);
+    }
+}

--- a/src/main/java/com/jangsacartel/biz/map/service/MapService.java
+++ b/src/main/java/com/jangsacartel/biz/map/service/MapService.java
@@ -1,0 +1,4 @@
+package com.jangsacartel.biz.map.service;
+
+public interface MapService {
+}

--- a/src/main/java/com/jangsacartel/biz/map/service/MapServiceImpl.java
+++ b/src/main/java/com/jangsacartel/biz/map/service/MapServiceImpl.java
@@ -1,0 +1,7 @@
+package com.jangsacartel.biz.map.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MapServiceImpl implements MapService {
+}

--- a/src/main/resources/mapper/board/BoardMapper.xml
+++ b/src/main/resources/mapper/board/BoardMapper.xml
@@ -201,7 +201,7 @@
             p.category_id = #{categoryId}
           AND p.deleted_at IS NULL
           <if test="region != null and region != ''">
-              AND ui.region = #{region}
+              AND ui.region LIKE CONCAT(#{region}, '%')
           </if>
         ORDER BY
             p.created_at DESC
@@ -219,7 +219,7 @@
             p.category_id = #{categoryId}
             AND p.deleted_at IS NULL
             <if test="region != null and region != ''">
-                AND ui.region = #{region}
+                AND ui.region LIKE CONCAT(#{region}, '%')
             </if>
     </select>
     
@@ -239,6 +239,24 @@
         ORDER BY
             like_count DESC, p.created_at DESC
         LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="findHotPostsByRegion" resultType="com.jangsacartel.biz.board.dto.BoardDTO">
+        SELECT
+            p.post_id,
+            p.title,
+            p.created_at,
+            (SELECT COUNT(*) FROM Like_Post WHERE post_id = p.post_id) as like_count,
+            (SELECT COUNT(*) FROM Comment WHERE post_id = p.post_id AND deleted_at IS NULL) as comment_count
+        FROM Post p
+        JOIN User_Info ui ON p.user_id = ui.user_id
+        WHERE p.deleted_at IS NULL
+          AND p.category_id = 4 -- '우리동네' category
+          <if test="region != null and region != ''">
+            AND ui.region LIKE CONCAT(#{region}, '%')
+          </if>
+        ORDER BY like_count DESC, p.created_at DESC
+        LIMIT #{limit}
     </select>
 
     <select id="countHotBoardPosts" resultType="int">

--- a/src/main/resources/mapper/map/MapMapper.xml
+++ b/src/main/resources/mapper/map/MapMapper.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.jangsacartel.biz.map.mapper.MapMapper">
+
+</mapper>


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 #19 

- #19 

### ✅ 작업한 내용

- 지도 페이지
1) 지도 구역에 마우스를 올려서 해당 구역의 이름 띄우기
2) 지도 클릭 시 시/동 값을 받아 그 구역을 필터 -> 해당 구역의 local 게시판 필터해서 보여주기

### ❗️PR Point

- 디자인 부분에서 수정사항이 있는지 확인해주세요
- 필터 부분에 혹시 문제는 없는지 확인해주세요

### 📸 스크린샷

<img width="432" height="830" alt="image" src="https://github.com/user-attachments/assets/c6116171-bb78-4b23-bd8a-0fab3d9df641" />

closed #19
